### PR TITLE
Comment out imaging quality and resampleFilter settings

### DIFF
--- a/hugo/config/_default/hugo.toml
+++ b/hugo/config/_default/hugo.toml
@@ -30,8 +30,8 @@ theme = "gallery"
   section = ["HTML"]
 
 [imaging]
-  quality = 75
-  resampleFilter = "CatmullRom"
+#  quality = 75
+#  resampleFilter = "CatmullRom"
   [imaging.exif]
     disableDate = false
     disableLatLong = true


### PR DESCRIPTION
The 'quality' and 'resampleFilter' options in the imaging section of hugo.toml have been commented out. use default values/disable custom image processing settings.